### PR TITLE
Add NuGet trusted-publishing workflow and centralize build metadata

### DIFF
--- a/.github/workflows/pr-build-test.yml
+++ b/.github/workflows/pr-build-test.yml
@@ -1,0 +1,26 @@
+name: PR Build and Test
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Restore
+        run: dotnet restore
+
+      - name: Build
+        run: dotnet build --configuration Release --no-restore
+
+      - name: Test
+        run: dotnet test --configuration Release --no-build --verbosity normal

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -7,15 +7,16 @@ on:
 jobs:
   publish:
     permissions:
+      contents: read
       id-token: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0   # MinVer needs full history + tags
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4
         with:
           dotnet-version: '10.0.x'
       - name: Restore
@@ -28,12 +29,37 @@ jobs:
         run: |
           dotnet pack src/Mediate/Mediate.csproj --configuration Release --no-build --output ./artifacts
           dotnet pack src/Mediate.BackgroundEventDispatch/Mediate.BackgroundEventDispatch.csproj --configuration Release --no-build --output ./artifacts
+      - name: Verify artifacts
+        run: |
+          shopt -s nullglob
+          packages=(./artifacts/*.nupkg)
+          symbols=(./artifacts/*.snupkg)
+
+          if [ ${#packages[@]} -eq 0 ]; then
+            echo "No .nupkg packages found in ./artifacts"
+            exit 1
+          fi
+
+          if [ ${#symbols[@]} -eq 0 ]; then
+            echo "No .snupkg packages found in ./artifacts"
+            exit 1
+          fi
+
+          echo "Found packages to publish:"
+          ls -la ./artifacts
       - name: NuGet login (OIDC)
-        uses: NuGet/login@v1
+        uses: NuGet/login@ebc737b6fc418a6ca0073cf116ec8dc156d8b81e # v1
         id: login
         with:
           user: ${{ secrets.NUGET_USER }}
       - name: Push
         run: |
-          dotnet nuget push "./artifacts/*.nupkg" --api-key ${{ steps.login.outputs.NUGET_API_KEY  }} --source https://api.nuget.org/v3/index.json --skip-duplicate
-          dotnet nuget push "./artifacts/*.snupkg" --api-key ${{ steps.login.outputs.NUGET_API_KEY  }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+          shopt -s nullglob
+
+          for package in ./artifacts/*.nupkg; do
+            dotnet nuget push "$package" --api-key ${{ steps.login.outputs.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+          done
+
+          for symbols in ./artifacts/*.snupkg; do
+            dotnet nuget push "$symbols" --api-key ${{ steps.login.outputs.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+          done

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -4,47 +4,36 @@ on:
   release:
     types: [published]
 
-permissions:
-  contents: read
-  id-token: write   # required for OIDC / trusted publishing
-
 jobs:
   publish:
+    permissions:
+      id-token: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0   # MinVer needs full history + tags
-
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '10.0.x'
-
       - name: Restore
         run: dotnet restore
-
       - name: Build
         run: dotnet build --configuration Release --no-restore
-
       - name: Test
         run: dotnet test --configuration Release --no-build --verbosity normal
-
       - name: Pack
         run: |
-          dotnet pack src/Mediate/Mediate.csproj \
-            --configuration Release --no-build --output ./artifacts
-          dotnet pack src/Mediate.BackgroundEventDispatch/Mediate.BackgroundEventDispatch.csproj \
-            --configuration Release --no-build --output ./artifacts
-
-      - name: NuGet login (OIDC -> temporary API key)
+          dotnet pack src/Mediate/Mediate.csproj --configuration Release --no-build --output ./artifacts
+          dotnet pack src/Mediate.BackgroundEventDispatch/Mediate.BackgroundEventDispatch.csproj --configuration Release --no-build --output ./artifacts
+      - name: NuGet login (OIDC)
         uses: NuGet/login@v1
         id: login
         with:
           user: ${{ secrets.NUGET_USER }}
-
       - name: Push
         run: |
-          dotnet nuget push "./artifacts/*.nupkg" --api-key ${{ steps.login.outputs.NUGET_AUTH_TOKEN }} --source https://api.nuget.org/v3/index.json --skip-duplicate
-          dotnet nuget push "./artifacts/*.snupkg" --api-key ${{ steps.login.outputs.NUGET_AUTH_TOKEN }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+          dotnet nuget push "./artifacts/*.nupkg" --api-key ${{ steps.login.outputs.NUGET_API_KEY  }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+          dotnet nuget push "./artifacts/*.snupkg" --api-key ${{ steps.login.outputs.NUGET_API_KEY  }} --source https://api.nuget.org/v3/index.json --skip-duplicate

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -45,8 +45,6 @@ jobs:
           user: ${{ secrets.NUGET_USER }}
 
       - name: Push
-        run: >
-          dotnet nuget push "./artifacts/*.nupkg"
-          --api-key ${{ steps.login.outputs.NUGET_API_KEY }}
-          --source https://api.nuget.org/v3/index.json
-          --skip-duplicate
+        run: |
+          dotnet nuget push "./artifacts/*.nupkg" --api-key ${{ steps.login.outputs.NUGET_AUTH_TOKEN }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+          dotnet nuget push "./artifacts/*.snupkg" --api-key ${{ steps.login.outputs.NUGET_AUTH_TOKEN }} --source https://api.nuget.org/v3/index.json --skip-duplicate

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -1,0 +1,52 @@
+name: Publish to NuGet
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  id-token: write   # required for OIDC / trusted publishing
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # MinVer needs full history + tags
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Restore
+        run: dotnet restore
+
+      - name: Build
+        run: dotnet build --configuration Release --no-restore
+
+      - name: Test
+        run: dotnet test --configuration Release --no-build --verbosity normal
+
+      - name: Pack
+        run: |
+          dotnet pack src/Mediate/Mediate.csproj \
+            --configuration Release --no-build --output ./artifacts
+          dotnet pack src/Mediate.BackgroundEventDispatch/Mediate.BackgroundEventDispatch.csproj \
+            --configuration Release --no-build --output ./artifacts
+
+      - name: NuGet login (OIDC -> temporary API key)
+        uses: NuGet/login@v1
+        id: login
+        with:
+          user: ${{ secrets.NUGET_USER }}
+
+      - name: Push
+        run: >
+          dotnet nuget push "./artifacts/*.nupkg"
+          --api-key ${{ steps.login.outputs.NUGET_API_KEY }}
+          --source https://api.nuget.org/v3/index.json
+          --skip-duplicate

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -20,7 +20,7 @@
     </PropertyGroup>
 
     <!-- Versioning (MinVer) + SourceLink / symbols -->
-    <PropertyGroup>
+    <PropertyGroup Condition="'$(IsPackable)' != 'false'">
         <MinVerTagPrefix>v</MinVerTagPrefix>
         <PublishRepositoryUrl>true</PublishRepositoryUrl>
         <IncludeSymbols>true</IncludeSymbols>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -34,7 +34,7 @@
         <None Include="$(MSBuildThisFileDirectory)logo.png" Pack="true" PackagePath="" />
     </ItemGroup>
 
-    <ItemGroup>
+    <ItemGroup Condition="'$(IsPackable)' != 'false'">
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300" PrivateAssets="all" />
         <PackageReference Include="MinVer" Version="7.0.0" PrivateAssets="all" />
     </ItemGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -28,7 +28,7 @@
         <EmbedUntrackedSources>true</EmbedUntrackedSources>
     </PropertyGroup>
 
-    <ItemGroup>
+    <ItemGroup Condition="'$(IsPackable)' != 'false'">
         <None Include="$(MSBuildThisFileDirectory)LICENSE.md" Pack="true" PackagePath="" />
         <None Include="$(MSBuildThisFileDirectory)README.md" Pack="true" PackagePath="" />
         <None Include="$(MSBuildThisFileDirectory)logo.png" Pack="true" PackagePath="" />

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,7 +8,7 @@
     </PropertyGroup>
 
     <!-- Shared NuGet package metadata for the packable projects -->
-    <PropertyGroup>
+    <PropertyGroup Condition="'$(IsPackable)' != 'false'">
         <PackageIcon>logo.png</PackageIcon>
         <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
         <PackageLicenseFile>LICENSE.md</PackageLicenseFile>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,42 @@
+<Project>
+
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <Authors>DementCore</Authors>
+        <Copyright>Copyright (c) 2026 DementCore</Copyright>
+        <Deterministic>true</Deterministic>
+    </PropertyGroup>
+
+    <!-- Shared NuGet package metadata for the packable projects -->
+    <PropertyGroup>
+        <PackageIcon>logo.png</PackageIcon>
+        <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
+        <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
+        <PackageProjectUrl>https://github.com/dementcore/Mediate</PackageProjectUrl>
+        <RepositoryUrl>https://github.com/dementcore/Mediate</RepositoryUrl>
+        <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    </PropertyGroup>
+
+    <!-- Versioning (MinVer) + SourceLink / symbols -->
+    <PropertyGroup>
+        <MinVerTagPrefix>v</MinVerTagPrefix>
+        <PublishRepositoryUrl>true</PublishRepositoryUrl>
+        <IncludeSymbols>true</IncludeSymbols>
+        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+        <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <None Include="$(MSBuildThisFileDirectory)LICENSE.md" Pack="true" PackagePath="" />
+        <None Include="$(MSBuildThisFileDirectory)README.md" Pack="true" PackagePath="" />
+        <None Include="$(MSBuildThisFileDirectory)logo.png" Pack="true" PackagePath="" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300" PrivateAssets="all" />
+        <PackageReference Include="MinVer" Version="7.0.0" PrivateAssets="all" />
+    </ItemGroup>
+
+</Project>

--- a/src/Mediate.BackgroundEventDispatch.Test/Mediate.BackgroundEventDispatch.Test.csproj
+++ b/src/Mediate.BackgroundEventDispatch.Test/Mediate.BackgroundEventDispatch.Test.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net10.0</TargetFramework>
         <LangVersion>latest</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
+        <GenerateDocumentationFile>false</GenerateDocumentationFile>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Mediate.BackgroundEventDispatch/Mediate.BackgroundEventDispatch.csproj
+++ b/src/Mediate.BackgroundEventDispatch/Mediate.BackgroundEventDispatch.csproj
@@ -1,26 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net10.0</TargetFramework>
-        <Authors>DementCore</Authors>
         <Product>Mediate.BackgroundEventDispatch</Product>
         <Description>Mediate.BackgroundEventDispatch is an event dispatch strategy for Mediate that enqueues event handlers to be executed by an Asp.Net Core hosted service. This system is intented to fire and forget an event.</Description>
-        <PackageIcon>logo.png</PackageIcon>
-        <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-        <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
-        <PackageReadmeFile>README.md</PackageReadmeFile>
-        <PackageProjectUrl>https://github.com/dementcore/Mediate</PackageProjectUrl>
-        <RepositoryUrl>https://github.com/dementcore/Mediate</RepositoryUrl>
-        <Copyright>Copyright (c) 2026 DementCore</Copyright>
-        <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-        <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <PackageTags>mediator;mediator-pattern;aspnetcore</PackageTags>
-        <MinVerTagPrefix>v</MinVerTagPrefix>
-        <PublishRepositoryUrl>true</PublishRepositoryUrl>
-        <IncludeSymbols>true</IncludeSymbols>
-        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-        <EmbedUntrackedSources>true</EmbedUntrackedSources>
-        <Deterministic>true</Deterministic>
     </PropertyGroup>
 
     <ItemGroup>
@@ -29,30 +12,6 @@
 
     <ItemGroup>
         <FrameworkReference Include="Microsoft.AspNetCore.App"/>
-    </ItemGroup>
-
-    <ItemGroup>
-        <None Include="..\..\LICENSE.md">
-            <Pack>True</Pack>
-            <PackagePath></PackagePath>
-        </None>
-        <None Include="..\..\README.md">
-            <Pack>True</Pack>
-            <PackagePath></PackagePath>
-        </None>
-        <None Include="..\..\logo.png">
-            <Pack>True</Pack>
-            <PackagePath></PackagePath>
-        </None>
-    </ItemGroup>
-
-    <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300">
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
-        <PackageReference Include="MinVer" Version="7.0.0">
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
     </ItemGroup>
 
 </Project>

--- a/src/Mediate.BackgroundEventDispatch/Mediate.BackgroundEventDispatch.csproj
+++ b/src/Mediate.BackgroundEventDispatch/Mediate.BackgroundEventDispatch.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <Product>Mediate.BackgroundEventDispatch</Product>
-        <Description>Mediate.BackgroundEventDispatch is an event dispatch strategy for Mediate that enqueues event handlers to be executed by an Asp.Net Core hosted service. This system is intented to fire and forget an event.</Description>
+        <Description>Mediate.BackgroundEventDispatch is an event dispatch strategy for Mediate that enqueues event handlers to be executed by an Asp.Net Core hosted service. This system is intended to fire and forget an event.</Description>
         <PackageTags>mediator;mediator-pattern;aspnetcore</PackageTags>
     </PropertyGroup>
 

--- a/src/Mediate.Test/Mediate.Test.csproj
+++ b/src/Mediate.Test/Mediate.Test.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net10.0</TargetFramework>
         <LangVersion>latest</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
+        <GenerateDocumentationFile>false</GenerateDocumentationFile>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Mediate/Mediate.csproj
+++ b/src/Mediate/Mediate.csproj
@@ -1,52 +1,13 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net10.0</TargetFramework>
-        <Authors>DementCore</Authors>
         <Product>Mediate</Product>
         <Description>Mediate is a simple and little in-process communication system based in mediator pattern</Description>
-        <PackageIcon>logo.png</PackageIcon>
-        <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-        <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
-        <PackageReadmeFile>README.md</PackageReadmeFile>
-        <PackageProjectUrl>https://github.com/dementcore/Mediate</PackageProjectUrl>
-        <RepositoryUrl>https://github.com/dementcore/Mediate</RepositoryUrl>
-        <Copyright>Copyright (c) 2026 DementCore</Copyright>
-        <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-        <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <PackageTags>mediator;mediator-pattern</PackageTags>
-        <MinVerTagPrefix>v</MinVerTagPrefix>
-        <PublishRepositoryUrl>true</PublishRepositoryUrl>
-        <IncludeSymbols>true</IncludeSymbols>
-        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-        <EmbedUntrackedSources>true</EmbedUntrackedSources>
-        <Deterministic>true</Deterministic>
     </PropertyGroup>
 
     <ItemGroup>
-        <None Include="..\..\LICENSE.md">
-            <Pack>True</Pack>
-            <PackagePath></PackagePath>
-        </None>
-        <None Include="..\..\README.md">
-            <Pack>True</Pack>
-            <PackagePath></PackagePath>
-        </None>
-        <None Include="..\..\logo.png">
-            <Pack>True</Pack>
-            <PackagePath></PackagePath>
-        </None>
-    </ItemGroup>
-
-    <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9"/>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-        <PackageReference Include="MinVer" Version="7.0.0">
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Add a GitHub Actions workflow that builds, tests, packs and publishes
Mediate and Mediate.BackgroundEventDispatch to NuGet.org on every
published GitHub Release, using NuGet trusted publishing (OIDC) instead
of a stored API key. The checkout uses fetch-depth: 0 so MinVer can see
git tags and derive the correct version in CI.

Centralize the shared packaging, MinVer and SourceLink metadata into a
root Directory.Build.props to remove duplication across the two packable
projects, and disable XML doc generation in the test projects.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>